### PR TITLE
Fix personality form radio button state issue

### DIFF
--- a/components/onboarding/MCQOption.tsx
+++ b/components/onboarding/MCQOption.tsx
@@ -36,7 +36,7 @@ export function MCQOption({
                 animate={
                     selected
                         ? { backgroundColor: "var(--primary)", color: "#fff" }
-                        : {}
+                        : { backgroundColor: "var(--background)", color: "var(--text-300)" }
                 }
                 transition={{ duration: 0.2 }}
                 className={`


### PR DESCRIPTION
When an option is deselected, explicitly reset the background and text colors in the Framer Motion animate prop to ensure previously selected options are properly unshaded.

Fixes #9