### PR TITLE
fix missing login failed bubble and account conflict messages

### DIFF
--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -36,6 +36,7 @@ export default function SignupPage() {
     const signup = useSignup();
     const [serverError, setServerError] = useState("");
     const [accountExists, setAccountExists] = useState(false);
+    const [conflictMessage, setConflictMessage] = useState<string>("");
     const { isAuthenticated, isLoading: authLoading } = useAuth();
     const draft = useOnboardingDraft((s) => s.signup);
     const setDraft = useOnboardingDraft((s) => s.setSignup);
@@ -79,6 +80,7 @@ export default function SignupPage() {
     const onSubmit = async (data: SignupFormData) => {
         setServerError("");
         setAccountExists(false);
+        setConflictMessage("");
         try {
             await signup.mutateAsync({
                 email: data.email,
@@ -93,6 +95,7 @@ export default function SignupPage() {
             if (axiosError.response?.status === 409) {
                 // Verified account already exists — direct them to log in and resume onboarding
                 setAccountExists(true);
+                setConflictMessage(axiosError.response?.data?.error?.message || "");
             } else {
                 setServerError(
                     axiosError.response?.data?.error?.message || "Something went wrong. Please try again."
@@ -160,7 +163,7 @@ export default function SignupPage() {
                         <StaggerItem className="pt-4">
                             <div className="rounded-xl bg-[var(--primary)]/10 border border-[var(--primary)]/20 px-4 py-3 text-center space-y-2">
                                 <p className="text-sm font-sans text-[var(--foreground)] font-medium">
-                                    You already have an account.
+                                    {conflictMessage || "You already have an account."}
                                 </p>
                                 <p className="text-xs font-sans text-[var(--text-300)]">
                                     Log in to pick up where you left off.

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -48,7 +48,9 @@ api.interceptors.request.use((config: InternalAxiosRequestConfig) => {
 api.interceptors.response.use(
     (response) => response,
     (error: AxiosError) => {
-        if (error.response?.status === 401) {
+        const url = error.config?.url ?? "";
+        const isAuthEndpoint = url.includes("/auth/");
+        if (error.response?.status === 401 && !isAuthEndpoint) {
             clearTokens();
             if (typeof window !== "undefined") {
                 window.location.href = "/login";


### PR DESCRIPTION
This pull request improves the signup experience by providing more detailed feedback when a user attempts to register with an email that already exists, and refines authentication error handling to avoid unnecessary redirects for authentication-related endpoints.

**Signup conflict messaging improvements:**

* Added a new `conflictMessage` state to `SignupPage`, which stores a specific error message from the backend when a signup conflict (HTTP 409) occurs. This message is now displayed to the user instead of a generic message, providing clearer feedback. [[1]](diffhunk://#diff-6573984fa57dc7e4e1fddb3716bbca8e1888c0af157bbe6db5118d8ef8e320ddR39) [[2]](diffhunk://#diff-6573984fa57dc7e4e1fddb3716bbca8e1888c0af157bbe6db5118d8ef8e320ddR98) [[3]](diffhunk://#diff-6573984fa57dc7e4e1fddb3716bbca8e1888c0af157bbe6db5118d8ef8e320ddL163-R166)
* Reset `conflictMessage` state on form submission to ensure stale messages are cleared.

**Authentication error handling:**

* Updated the Axios response interceptor in `lib/api/client.ts` to avoid redirecting to the login page when a 401 error occurs on authentication endpoints (URLs containing `/auth/`). This prevents unnecessary redirects during authentication flows.