### PR TITLE
hotfix

### DIFF
--- a/app/(onboarding)/questionnaire/page.tsx
+++ b/app/(onboarding)/questionnaire/page.tsx
@@ -69,6 +69,20 @@ export default function QuestionnairePage() {
     const [currentSectionIndex, setCurrentSectionIndex] = useState(draft.currentSectionIndex);
     const [answers, setAnswers] = useState<Record<number, string>>(draft.answers);
 
+    // Seed default answers for slider questions so the Next button isn't
+    // blocked when the user leaves a slider at its initial position.
+    const seededAnswers = useMemo(() => {
+        if (!questions) return answers;
+        const defaults: Record<number, string> = {};
+        for (const q of questions) {
+            if (q.type === "slider" && answers[q.id] === undefined) {
+                defaults[q.id] = String(q.slider_min ?? 1);
+            }
+        }
+        if (Object.keys(defaults).length === 0) return answers;
+        return { ...defaults, ...answers };
+    }, [questions, answers]);
+
     const sections = useMemo(
         () => (questions ? groupQuestions(questions) : []),
         [questions]
@@ -78,7 +92,7 @@ export default function QuestionnairePage() {
     const isLastSection = currentSectionIndex === sections.length - 1;
 
     const allCurrentAnswered = currentSection?.questions.every(
-        (q) => answers[q.id] !== undefined && answers[q.id] !== ""
+        (q) => seededAnswers[q.id] !== undefined && seededAnswers[q.id] !== ""
     );
 
     const handleMCQAnswer = (questionId: number, answer: string) => {
@@ -104,7 +118,7 @@ export default function QuestionnairePage() {
 
         // Final section — submit all answers
         try {
-            const answerPayload = Object.entries(answers).map(
+            const answerPayload = Object.entries(seededAnswers).map(
                 ([qId, answer]) => ({
                     question_id: parseInt(qId),
                     answer,
@@ -197,7 +211,7 @@ export default function QuestionnairePage() {
                                                         optionKey={option.key}
                                                         text={option.text}
                                                         selected={
-                                                            answers[question.id] ===
+                                                            seededAnswers[question.id] ===
                                                             option.key
                                                         }
                                                         onClick={() =>
@@ -220,8 +234,8 @@ export default function QuestionnairePage() {
                                         question.slider_labels?.[1] || ""
                                     }
                                     value={
-                                        answers[question.id]
-                                            ? parseInt(answers[question.id])
+                                        seededAnswers[question.id]
+                                            ? parseInt(seededAnswers[question.id])
                                             : question.slider_min || 1
                                     }
                                     onChange={(value) =>

--- a/app/(onboarding)/skills/page.tsx
+++ b/app/(onboarding)/skills/page.tsx
@@ -122,7 +122,11 @@ export default function SkillsPage() {
                 </FadeIn>
 
                 <button
-                    onClick={() => router.push("/intent")}
+                    onClick={async () => {
+                        await updateSkills.mutateAsync({ tags: [] });
+                        clearDraft();
+                        router.push("/intent");
+                    }}
                     className="block w-full text-center text-sm text-[var(--text-200)] font-sans hover:text-[var(--text-300)] transition-colors"
                 >
                     Skip for now


### PR DESCRIPTION
This pull request improves the onboarding questionnaire and skills pages by enhancing the user experience for slider questions and ensuring draft state is properly cleared when skipping skills selection. The most important changes are grouped below:

**Onboarding Questionnaire Improvements:**

* Slider questions now have default answers seeded automatically, so the "Next" button is enabled even if the user leaves a slider at its initial position. This prevents users from being blocked by unanswered slider questions. All answer-related logic has been updated to use these seeded defaults. [[1]](diffhunk://#diff-c5e8f5c09c5fb314935fea718cc0c05a2c3a9063579d75338f1774e2dbafec85R72-R85) [[2]](diffhunk://#diff-c5e8f5c09c5fb314935fea718cc0c05a2c3a9063579d75338f1774e2dbafec85L81-R95) [[3]](diffhunk://#diff-c5e8f5c09c5fb314935fea718cc0c05a2c3a9063579d75338f1774e2dbafec85L107-R121) [[4]](diffhunk://#diff-c5e8f5c09c5fb314935fea718cc0c05a2c3a9063579d75338f1774e2dbafec85L200-R214) [[5]](diffhunk://#diff-c5e8f5c09c5fb314935fea718cc0c05a2c3a9063579d75338f1774e2dbafec85L223-R238)

**Skills Page Enhancement:**

* When a user clicks "Skip for now" on the skills selection page, the draft state is cleared and an API call is made to update skills with an empty tag list before navigating to the next page. This ensures no stale draft data is retained.