### PR TITLE
fix: ensure Discovery page fully loads before rendering recommendation

### DIFF
--- a/app/(app)/discover/page.tsx
+++ b/app/(app)/discover/page.tsx
@@ -12,7 +12,7 @@ import { RequestSentModal } from "@/components/app/discovery/RequestSentModal";
 import { DeclinedToast } from "@/components/app/discovery/DeclinedToast";
 
 export default function DiscoverPage() {
-    const { data, isLoading, error } = useDiscovery();
+    const { data, isLoading, isFetching, error } = useDiscovery();
     const skipMutation = useSkipProfile();
     const sendRequestMutation = useSendRequest();
 
@@ -48,7 +48,8 @@ export default function DiscoverPage() {
         setShowRequestSent(false);
     }, []);
 
-    if (isLoading) {
+    // Show loading spinner during initial load or when fetching
+    if (isLoading || (isFetching && !data)) {
         return (
             <div className="flex flex-col min-h-dvh">
                 <DiscoveryHeader />
@@ -82,7 +83,7 @@ export default function DiscoverPage() {
                 />
             )}
 
-            {recommendation && (
+            {recommendation && recommendation.profile.first_name && (
                 <div className="flex-1 pb-20">
                     <RecommendationCard
                         recommendation={recommendation}


### PR DESCRIPTION
## Summary

This PR fixes issue #17 where the Discovery page would not fully load on first visit, with recommendation names appearing missing until the page was reloaded.

## Changes

- Added `isFetching` check to loading condition to handle all data fetching states
- Show loading spinner when data is being fetched but not yet available
- Added safety check for `recommendation.profile.first_name` before rendering card

## Root Cause

The component was only checking React Query's `isLoading` state, which is only true during the initial fetch. When the component mounted with stale or partial data, it would render the UI before the recommendation data was fully loaded, resulting in missing names.

## Testing

1. Navigate to Discovery page from any other page
2. Verify the recommendation name appears correctly on first load
3. Navigate away and back to confirm consistent behavior

Closes #17

Generated with [Claude Code](https://claude.ai/code)