### PR TITLE
feat: make connection request cards clickable to view sender profiles

### DIFF
--- a/app/(app)/notifications/page.tsx
+++ b/app/(app)/notifications/page.tsx
@@ -96,7 +96,10 @@ export default function NotificationsPage() {
                                     className="bg-white rounded-xl p-4 shadow-[0_0_7px_rgba(0,0,0,0.08)]"
                                 >
                                     {/* Top row: avatar + name/headline */}
-                                    <div className="flex items-center gap-3 mb-3">
+                                    <div
+                                        onClick={() => router.push(`/discover/${req.sender.user_id}`)}
+                                        className="flex items-center gap-3 mb-3 cursor-pointer hover:opacity-80 transition-opacity"
+                                    >
                                         <div className="w-12 h-12 rounded-full bg-[#e8d5c8] flex-shrink-0 overflow-hidden">
                                             {req.sender.photo_url && (
                                                 <img


### PR DESCRIPTION
## Summary

This PR fixes issue #18 by making connection request cards in the notifications page clickable. Users can now view the full profile of people sending them connection requests before accepting or declining.

## Changes

- Made the connection request card (avatar, name, headline) clickable
- Added navigation to `/discover/${user_id}` when clicked
- Added hover effects for better UX

## Testing

1. Navigate to the notifications page
2. Find a connection request
3. Click on the sender's avatar, name, or headline
4. Verify that it navigates to the sender's profile page

Fixes #18

Generated with [Claude Code](https://claude.ai/code)