### PR TITLE
fix: vertically center text in questionnaire options

### DIFF
--- a/components/onboarding/MCQOption.tsx
+++ b/components/onboarding/MCQOption.tsx
@@ -23,7 +23,7 @@ export function MCQOption({
             animate={selected ? { scale: [1, 1.03, 1] } : { scale: 1 }}
             transition={{ duration: 0.2, ease: "easeInOut" }}
             className={`
-                w-full flex items-start gap-3 px-4 py-3.5 rounded-xl
+                w-full flex items-center gap-3 px-4 py-3.5 rounded-xl
                 text-left font-sans text-sm transition-all duration-200
                 ${
                     selected
@@ -41,7 +41,7 @@ export function MCQOption({
                 transition={{ duration: 0.2 }}
                 className={`
                     flex-shrink-0 w-6 h-6 rounded-full flex items-center justify-center
-                    text-xs font-semibold mt-0.5
+                    text-xs font-semibold
                     ${
                         selected
                             ? "bg-[var(--primary)] text-white"


### PR DESCRIPTION
Changed flex alignment from items-start to items-center in MCQOption component to properly align option text and key circles vertically. Also removed unnecessary mt-0.5 margin.

Fixes #36