### PR TITLE
otp pwd reset

### DIFF
--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { OnboardingLayout, BottomButton } from "@/components/onboarding";
+import { PhoneInput } from "@/components/onboarding/PhoneInput";
+import { useForgotPassword } from "@/lib/api/hooks";
+import { useState } from "react";
+import Link from "next/link";
+import { AxiosError } from "axios";
+import { ApiError } from "@/lib/api/types";
+import { StaggerContainer, StaggerItem } from "@/components/onboarding/animations";
+
+const forgotPasswordSchema = z.object({
+    phone: z
+        .string()
+        .min(10, "Please enter a valid phone number")
+        .regex(/^\+?[0-9\s-]+$/, "Please enter a valid phone number"),
+});
+
+type ForgotPasswordFormData = z.infer<typeof forgotPasswordSchema>;
+
+export default function ForgotPasswordPage() {
+    const router = useRouter();
+    const forgotPassword = useForgotPassword();
+    const [serverError, setServerError] = useState("");
+
+    const {
+        setValue,
+        watch,
+        handleSubmit,
+        formState: { errors, isValid },
+    } = useForm<ForgotPasswordFormData>({
+        resolver: zodResolver(forgotPasswordSchema),
+        mode: "onChange",
+        defaultValues: {
+            phone: "",
+        },
+    });
+
+    const phone = watch("phone");
+
+    const onSubmit = async (data: ForgotPasswordFormData) => {
+        setServerError("");
+        try {
+            await forgotPassword.mutateAsync({ phone: data.phone });
+            // Navigate to verify page with phone number
+            router.push(`/forgot-password/verify?phone=${encodeURIComponent(data.phone)}`);
+        } catch (err) {
+            const axiosError = err as AxiosError<ApiError>;
+            const msg = axiosError.response?.data?.error?.message || "";
+            if (axiosError.response?.status === 429) {
+                setServerError("Too many requests. Please wait before trying again.");
+            } else {
+                setServerError(msg || "Something went wrong. Please try again.");
+            }
+        }
+    };
+
+    return (
+        <OnboardingLayout showBack={true} showLogo={true} onBack={() => router.push("/login")}>
+            <form
+                onSubmit={handleSubmit(onSubmit)}
+                className="pt-6 space-y-6"
+            >
+                <StaggerContainer staggerDelay={0.07} delayChildren={0.05}>
+                    <StaggerItem>
+                        <div className="space-y-2">
+                            <h1 className="text-2xl font-serif font-bold text-[var(--foreground)]">
+                                Forgot Password
+                            </h1>
+                            <p className="text-sm text-[var(--text-300)] font-sans">
+                                Enter your phone number and we&apos;ll send you a verification code to reset your password.
+                            </p>
+                        </div>
+                    </StaggerItem>
+
+                    <StaggerItem className="pt-6">
+                        <PhoneInput
+                            label="Phone Number"
+                            value={phone}
+                            onChange={(value) => setValue("phone", value, { shouldValidate: true })}
+                            error={errors.phone?.message}
+                        />
+                    </StaggerItem>
+
+                    {serverError && (
+                        <StaggerItem className="pt-2">
+                            <div className="rounded-xl bg-red-50 border border-red-200 px-4 py-3 text-center">
+                                <p className="text-sm font-sans text-red-700">
+                                    {serverError}
+                                </p>
+                            </div>
+                        </StaggerItem>
+                    )}
+
+                    <StaggerItem className="pt-4">
+                        <p className="text-xs text-[var(--text-200)] text-center font-sans">
+                            Remember your password?{" "}
+                            <Link
+                                href="/login"
+                                className="text-[var(--primary)] font-medium"
+                            >
+                                Log In
+                            </Link>
+                        </p>
+                    </StaggerItem>
+                </StaggerContainer>
+
+                <BottomButton
+                    type="submit"
+                    disabled={!isValid}
+                    loading={forgotPassword.isPending}
+                >
+                    Send Code
+                </BottomButton>
+            </form>
+        </OnboardingLayout>
+    );
+}

--- a/app/(auth)/forgot-password/reset/page.tsx
+++ b/app/(auth)/forgot-password/reset/page.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { OnboardingLayout, InputField, BottomButton } from "@/components/onboarding";
+import { useResetPassword } from "@/lib/api/hooks";
+import { useState, Suspense } from "react";
+import { AxiosError } from "axios";
+import { ApiError } from "@/lib/api/types";
+import { StaggerContainer, StaggerItem } from "@/components/onboarding/animations";
+
+const resetPasswordSchema = z.object({
+    password: z
+        .string()
+        .min(8, "Password must be at least 8 characters"),
+    confirmPassword: z
+        .string()
+        .min(8, "Password must be at least 8 characters"),
+}).refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+});
+
+type ResetPasswordFormData = z.infer<typeof resetPasswordSchema>;
+
+function ResetPasswordContent() {
+    const router = useRouter();
+    const searchParams = useSearchParams();
+    const token = searchParams.get("token") || "";
+    const resetPassword = useResetPassword();
+    const [serverError, setServerError] = useState("");
+    const [success, setSuccess] = useState(false);
+
+    const {
+        register,
+        handleSubmit,
+        formState: { errors, isValid },
+    } = useForm<ResetPasswordFormData>({
+        resolver: zodResolver(resetPasswordSchema),
+        mode: "onChange",
+    });
+
+    const onSubmit = async (data: ResetPasswordFormData) => {
+        setServerError("");
+        try {
+            await resetPassword.mutateAsync({
+                token,
+                new_password: data.password,
+            });
+            setSuccess(true);
+            // Redirect to login after 2 seconds
+            setTimeout(() => {
+                router.push("/login");
+            }, 2000);
+        } catch (err) {
+            const axiosError = err as AxiosError<ApiError>;
+            const msg = axiosError.response?.data?.error?.message || "";
+            if (msg.toLowerCase().includes("expired")) {
+                setServerError("Reset link has expired. Please request a new one.");
+            } else if (msg.toLowerCase().includes("used")) {
+                setServerError("This reset link has already been used.");
+            } else if (msg.toLowerCase().includes("invalid")) {
+                setServerError("Invalid reset link. Please request a new one.");
+            } else {
+                setServerError(msg || "Something went wrong. Please try again.");
+            }
+        }
+    };
+
+    if (success) {
+        return (
+            <OnboardingLayout showBack={false} showLogo={true}>
+                <div className="pt-10 space-y-8">
+                    <StaggerContainer staggerDelay={0.08} delayChildren={0.05}>
+                        <StaggerItem>
+                            <div className="text-center space-y-4">
+                                <div className="w-16 h-16 mx-auto bg-green-100 rounded-full flex items-center justify-center">
+                                    <svg
+                                        className="w-8 h-8 text-green-600"
+                                        fill="none"
+                                        stroke="currentColor"
+                                        viewBox="0 0 24 24"
+                                    >
+                                        <path
+                                            strokeLinecap="round"
+                                            strokeLinejoin="round"
+                                            strokeWidth={2}
+                                            d="M5 13l4 4L19 7"
+                                        />
+                                    </svg>
+                                </div>
+                                <h1 className="text-2xl font-serif font-bold text-[var(--foreground)]">
+                                    Password Reset!
+                                </h1>
+                                <p className="text-sm text-[var(--text-300)] font-sans">
+                                    Your password has been successfully reset. Redirecting you to login...
+                                </p>
+                            </div>
+                        </StaggerItem>
+                    </StaggerContainer>
+                </div>
+            </OnboardingLayout>
+        );
+    }
+
+    return (
+        <OnboardingLayout showBack={true} showLogo={true} onBack={() => router.push("/login")}>
+            <form
+                onSubmit={handleSubmit(onSubmit)}
+                className="pt-6 space-y-6"
+            >
+                <StaggerContainer staggerDelay={0.07} delayChildren={0.05}>
+                    <StaggerItem>
+                        <div className="space-y-2">
+                            <h1 className="text-2xl font-serif font-bold text-[var(--foreground)]">
+                                Reset Password
+                            </h1>
+                            <p className="text-sm text-[var(--text-300)] font-sans">
+                                Enter your new password below.
+                            </p>
+                        </div>
+                    </StaggerItem>
+
+                    <StaggerItem className="pt-6">
+                        <InputField
+                            label="New Password"
+                            type="password"
+                            placeholder="Enter your new password"
+                            autoComplete="new-password"
+                            error={errors.password?.message}
+                            {...register("password")}
+                        />
+                    </StaggerItem>
+
+                    <StaggerItem className="pt-4">
+                        <InputField
+                            label="Confirm Password"
+                            type="password"
+                            placeholder="Confirm your new password"
+                            autoComplete="new-password"
+                            error={errors.confirmPassword?.message}
+                            {...register("confirmPassword")}
+                        />
+                    </StaggerItem>
+
+                    {serverError && (
+                        <StaggerItem className="pt-2">
+                            <div className="rounded-xl bg-red-50 border border-red-200 px-4 py-3 text-center space-y-2">
+                                <p className="text-sm font-sans text-red-700">
+                                    {serverError}
+                                </p>
+                                {(serverError.includes("expired") || serverError.includes("used") || serverError.includes("Invalid")) && (
+                                    <button
+                                        type="button"
+                                        onClick={() => router.push("/forgot-password")}
+                                        className="text-sm text-[var(--primary)] font-medium hover:underline"
+                                    >
+                                        Request new reset link
+                                    </button>
+                                )}
+                            </div>
+                        </StaggerItem>
+                    )}
+                </StaggerContainer>
+
+                <BottomButton
+                    type="submit"
+                    disabled={!isValid || !token}
+                    loading={resetPassword.isPending}
+                >
+                    Reset Password
+                </BottomButton>
+            </form>
+        </OnboardingLayout>
+    );
+}
+
+export default function ResetPasswordPage() {
+    return (
+        <Suspense
+            fallback={
+                <div className="min-h-dvh bg-[var(--background)] flex items-center justify-center">
+                    <div className="w-8 h-8 border-2 border-[var(--primary)] border-t-transparent rounded-full animate-spin" />
+                </div>
+            }
+        >
+            <ResetPasswordContent />
+        </Suspense>
+    );
+}

--- a/app/(auth)/forgot-password/verify/page.tsx
+++ b/app/(auth)/forgot-password/verify/page.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState, useEffect, useCallback, Suspense } from "react";
+import { OnboardingLayout, OTPInput, BottomButton } from "@/components/onboarding";
+import { useVerifyPasswordResetOTP, useForgotPassword } from "@/lib/api/hooks";
+import { AxiosError } from "axios";
+import { ApiError } from "@/lib/api/types";
+import { StaggerContainer, StaggerItem } from "@/components/onboarding/animations";
+
+function VerifyPasswordResetContent() {
+    const router = useRouter();
+    const searchParams = useSearchParams();
+    const phone = searchParams.get("phone") || "";
+
+    const [otp, setOtp] = useState("");
+    const [error, setError] = useState("");
+    const [resendTimer, setResendTimer] = useState(30);
+    const [resendMessage, setResendMessage] = useState("");
+
+    const verifyOTP = useVerifyPasswordResetOTP();
+    const resendOTP = useForgotPassword();
+
+    // Countdown timer
+    useEffect(() => {
+        if (resendTimer <= 0) return;
+        const interval = setInterval(() => {
+            setResendTimer((prev) => prev - 1);
+        }, 1000);
+        return () => clearInterval(interval);
+    }, [resendTimer]);
+
+    const handleVerify = useCallback(async () => {
+        if (otp.length !== 6) return;
+        if (verifyOTP.isPending) return;
+        setError("");
+        try {
+            const response = await verifyOTP.mutateAsync({ phone, code: otp });
+            // Navigate to reset page with the reset token
+            const resetToken = response.data.reset_token;
+            router.push(`/forgot-password/reset?token=${encodeURIComponent(resetToken)}`);
+        } catch (err) {
+            const axiosError = err as AxiosError<ApiError>;
+            setError(
+                axiosError.response?.data?.error?.message ||
+                    "Incorrect verification code. Please try again."
+            );
+        }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [otp, phone, verifyOTP.mutateAsync, router]);
+
+    // Auto-submit when all 6 digits entered
+    useEffect(() => {
+        if (otp.length === 6) {
+            handleVerify();
+        }
+    }, [otp, handleVerify]);
+
+    const handleResend = async () => {
+        try {
+            await resendOTP.mutateAsync({ phone });
+            setResendTimer(30);
+            setResendMessage("OTP has been resent");
+            setError("");
+            setOtp("");
+            setTimeout(() => setResendMessage(""), 3000);
+        } catch {
+            setError("Failed to resend OTP. Please try again.");
+        }
+    };
+
+    const formatTimer = (seconds: number) => {
+        const m = Math.floor(seconds / 60);
+        const s = seconds % 60;
+        return `${m}:${s.toString().padStart(2, "0")}`;
+    };
+
+    return (
+        <OnboardingLayout showBack={true} showLogo={true} onBack={() => router.push("/forgot-password")}>
+            <div className="pt-10 space-y-8">
+                <StaggerContainer staggerDelay={0.08} delayChildren={0.05}>
+                    <StaggerItem>
+                        <div className="text-center space-y-2">
+                            <h1 className="text-2xl font-serif font-bold text-[var(--foreground)]">
+                                Verify Your Phone
+                            </h1>
+                            <p className="text-sm text-[var(--text-300)] font-sans">
+                                Please enter the 6-digit verification code sent to{" "}
+                                <span className="font-semibold text-[var(--text-400)]">
+                                    {phone}
+                                </span>
+                            </p>
+                        </div>
+                    </StaggerItem>
+
+                    <StaggerItem className="pt-6">
+                        <OTPInput
+                            value={otp}
+                            onChange={setOtp}
+                            error={error}
+                            disabled={verifyOTP.isPending}
+                        />
+                    </StaggerItem>
+
+                    {resendMessage && (
+                        <StaggerItem>
+                            <p className="text-sm text-green-600 font-sans text-center">
+                                {resendMessage}
+                            </p>
+                        </StaggerItem>
+                    )}
+
+                    <StaggerItem className="pt-2">
+                        <div className="text-center">
+                            {resendTimer > 0 ? (
+                                <p className="text-sm text-[var(--text-200)] font-sans">
+                                    Resend code in{" "}
+                                    <span className="font-medium">
+                                        {formatTimer(resendTimer)}
+                                    </span>
+                                </p>
+                            ) : (
+                                <button
+                                    onClick={handleResend}
+                                    disabled={resendOTP.isPending}
+                                    className="text-sm text-[var(--primary)] font-sans font-medium hover:underline disabled:opacity-50"
+                                >
+                                    Resend code
+                                </button>
+                            )}
+                        </div>
+                    </StaggerItem>
+                </StaggerContainer>
+
+                <BottomButton
+                    onClick={handleVerify}
+                    disabled={otp.length !== 6}
+                    loading={verifyOTP.isPending}
+                >
+                    Verify
+                </BottomButton>
+            </div>
+        </OnboardingLayout>
+    );
+}
+
+export default function VerifyPasswordResetPage() {
+    return (
+        <Suspense
+            fallback={
+                <div className="min-h-dvh bg-[var(--background)] flex items-center justify-center">
+                    <div className="w-8 h-8 border-2 border-[var(--primary)] border-t-transparent rounded-full animate-spin" />
+                </div>
+            }
+        >
+            <VerifyPasswordResetContent />
+        </Suspense>
+    );
+}

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -118,6 +118,17 @@ export default function LoginPage() {
                         />
                     </StaggerItem>
 
+                    <StaggerItem className="pt-1">
+                        <div className="text-right">
+                            <Link
+                                href="/forgot-password"
+                                className="text-xs text-[var(--primary)] font-medium hover:underline"
+                            >
+                                Forgot Password?
+                            </Link>
+                        </div>
+                    </StaggerItem>
+
                     {errorType === "credentials" && (
                         <StaggerItem className="pt-2">
                             <div className="rounded-xl bg-red-50 border border-red-200 px-4 py-3 text-center space-y-1">

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -153,6 +153,15 @@ export const authApi = {
 
     resendOTP: (data: import("./types").ResendOTPRequest) =>
         api.post<import("./types").OTPResponse>("/auth/resend-otp", data),
+
+    forgotPassword: (data: import("./types").ForgotPasswordRequest) =>
+        api.post<import("./types").ForgotPasswordResponse>("/auth/forgot-password", data),
+
+    verifyPasswordResetOTP: (data: import("./types").VerifyPasswordResetOTPRequest) =>
+        api.post<import("./types").VerifyPasswordResetOTPResponse>("/auth/verify-password-reset-otp", data),
+
+    resetPassword: (data: import("./types").ResetPasswordRequest) =>
+        api.post<import("./types").ResetPasswordResponse>("/auth/reset-password", data),
 };
 
 // ── Profile API ───────────────────────────────────────────

--- a/lib/api/hooks/use-auth.ts
+++ b/lib/api/hooks/use-auth.ts
@@ -7,6 +7,12 @@ import type {
     LoginRequest,
     VerifyOTPRequest,
     ResendOTPRequest,
+    ForgotPasswordRequest,
+    ForgotPasswordResponse,
+    VerifyPasswordResetOTPRequest,
+    VerifyPasswordResetOTPResponse,
+    ResetPasswordRequest,
+    ResetPasswordResponse,
     AuthResponse,
     OTPResponse,
 } from "../types";
@@ -40,5 +46,23 @@ export function useVerifyOTP(options?: {
 export function useResendOTP() {
     return useMutation<AxiosResponse<OTPResponse>, Error, ResendOTPRequest>({
         mutationFn: (data) => authApi.resendOTP(data),
+    });
+}
+
+export function useForgotPassword() {
+    return useMutation<AxiosResponse<ForgotPasswordResponse>, Error, ForgotPasswordRequest>({
+        mutationFn: (data) => authApi.forgotPassword(data),
+    });
+}
+
+export function useVerifyPasswordResetOTP() {
+    return useMutation<AxiosResponse<VerifyPasswordResetOTPResponse>, Error, VerifyPasswordResetOTPRequest>({
+        mutationFn: (data) => authApi.verifyPasswordResetOTP(data),
+    });
+}
+
+export function useResetPassword() {
+    return useMutation<AxiosResponse<ResetPasswordResponse>, Error, ResetPasswordRequest>({
+        mutationFn: (data) => authApi.resetPassword(data),
     });
 }

--- a/lib/api/types.ts
+++ b/lib/api/types.ts
@@ -68,6 +68,34 @@ export interface ResendOTPRequest {
     phone: string;
 }
 
+export interface ForgotPasswordRequest {
+    phone: string;
+}
+
+export interface ForgotPasswordResponse {
+    message: string;
+    expires_in: number;
+}
+
+export interface VerifyPasswordResetOTPRequest {
+    phone: string;
+    code: string;
+}
+
+export interface VerifyPasswordResetOTPResponse {
+    reset_token: string;
+    expires_in: number;
+}
+
+export interface ResetPasswordRequest {
+    token: string;
+    new_password: string;
+}
+
+export interface ResetPasswordResponse {
+    message: string;
+}
+
 export interface AuthResponse {
     access_token: string;
     refresh_token: string;


### PR DESCRIPTION
This pull request implements a complete "Forgot Password" flow for the authentication system. It introduces new pages and API hooks for requesting a password reset, verifying an OTP sent to the user's phone, and setting a new password. Additionally, it updates the login page to link to the new flow and expands the API client and types to support the new endpoints.

The most important changes are:

**New Forgot Password Flow Pages:**
- Added `forgot-password` page for users to request a password reset by entering their phone number, including validation, error handling, and navigation to verification.
- Added `forgot-password/verify` page for OTP entry and verification, with resend functionality and error feedback.
- Added `forgot-password/reset` page to set a new password using a reset token, with validation, error handling, and success feedback.

**API Client and Hooks:**
- Expanded `authApi` in `lib/api/client.ts` with new methods: `forgotPassword`, `verifyPasswordResetOTP`, and `resetPassword` to interact with the backend for the new flow.
- Added corresponding React hooks: `useForgotPassword`, `useVerifyPasswordResetOTP`, and `useResetPassword` for use in the new pages.

**Types and Validation:**
- Added new TypeScript interfaces for the forgot password flow requests and responses (`ForgotPasswordRequest`, `ForgotPasswordResponse`, `VerifyPasswordResetOTPRequest`, `VerifyPasswordResetOTPResponse`, `ResetPasswordRequest`, `ResetPasswordResponse`). [[1]](diffhunk://#diff-0c0f3a34ecf62a29d443a8ffe87a42e97191e81ac1004ec85d077a5f0afa6891R71-R98) [[2]](diffhunk://#diff-85010411dd6ef877d7bf98346ee18fcf33da14190a57c5b1765b957ed36250eeR10-R15)

**UI/UX Improvements:**
- Updated the login page to include a "Forgot Password?" link, providing easy access to the new flow.

These changes together provide a robust, user-friendly password reset experience via phone number and OTP verification.