### PR TITLE
fix: resolve session state race condition on backend restart

### DIFF
--- a/lib/auth/context.tsx
+++ b/lib/auth/context.tsx
@@ -62,12 +62,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                     setTokens(access_token, refresh_token);
                     localStorage.setItem(USER_STORAGE_KEY, JSON.stringify(user));
                     setUserState(user);
+                    setIsLoading(false);
                 }
             } catch {
                 clearTokens();
                 localStorage.removeItem(USER_STORAGE_KEY);
                 setUserState(null);
-            } finally {
                 setIsLoading(false);
             }
         };


### PR DESCRIPTION
Fix issue where users were redirected to profile creation page instead of login page after backend restart. The problem was a race condition in the session restoration logic where isLoading was set to false in a finally block, allowing React to read stale user state before it was properly cleared.

Moved setIsLoading(false) into the success and error paths to ensure state updates happen in the correct order, eliminating the race condition.

Fixes #48